### PR TITLE
PoC for forwarding of additional options to Gotenberg

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in gotenberg.gemspec
 gemspec
 
-gem "rake", "~> 13.0"
+group :development, :test do
+  gem "rspec", "~> 3.0"
+  gem "webmock"
+  gem "multipart-parser"
+end
 
-gem "rspec", "~> 3.0"
+gem "rake", "~> 13.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
+    crack (0.4.5)
+      rexml
     diff-lcs (1.5.0)
     faraday (2.7.2)
       faraday-net_http (>= 2.0, < 3.1)
@@ -15,8 +19,12 @@ GEM
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
+    hashdiff (1.0.1)
+    multipart-parser (0.1.1)
     multipart-post (2.2.3)
+    public_suffix (5.0.1)
     rake (13.0.6)
+    rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -31,14 +39,20 @@ GEM
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
     ruby2_keywords (0.0.5)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
   gotenberg-client!
+  multipart-parser
   rake (~> 13.0)
   rspec (~> 3.0)
+  webmock
 
 BUNDLED WITH
    2.3.26

--- a/lib/gotenberg.rb
+++ b/lib/gotenberg.rb
@@ -27,18 +27,20 @@ module Gotenberg
     # @param render [String] HTML to convert
     # @param output [File, Pathname, #write] Output file
     # @return true if everything OK
-    def html(render, output)
-      return false unless self.up?
+    def html(render, output, **kwargs)
+      return false unless up?
 
-      payload = {
+      content = {
         "index.html": Faraday::Multipart::FilePart.new(
           StringIO.new(render),
           'text/html',
           "index.html"
-          )
+        ),
       }
-      url = "#{@api_url}/forms/chromium/convert/html"
-      begin
+
+      payload = kwargs.merge(content)
+
+      url = "#{@api_url}/forms/chromium/convert/html" begin
         conn = Faraday.new(url) do |f|
           f.request :multipart, flat_encode: true
           f.adapter :net_http

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,65 @@
+
+RSpec.describe Gotenberg::Client do
+  let (:client) { described_class.new("http://gotenberg.example.com") }
+  before do
+    stub_request(:post, "http://gotenberg.example.com/forms/chromium/convert/html")
+  end
+
+  context "service down" do
+    before do
+      stub_request(:get, "http://gotenberg.example.com/health").to_return(status: 502, body: 'Bad Gateway')
+    end
+
+    describe "#up?" do
+      it "returns false" do
+        client_status = client.up?
+
+        expect(client_status).to eq(false)
+      end
+    end
+
+    describe "#html" do
+      it "returns early without doing a request" do
+        result = client.html("<html />", StringIO.new)
+
+        expect(result).to eq(false)
+        expect(a_request(:post, "http://gotenberg.example.com/forms/chromium/convert/html")).not_to have_been_made
+
+      end
+    end
+  end
+
+  context "service up" do
+    before do
+      stub_request(:get, "http://gotenberg.example.com/health").to_return(status: 200, body: '{"status": "up"}')
+    end
+
+    describe '#up?' do
+      it "returns true if service is up" do
+        client_status = client.up?
+
+        expect(client_status).to eq(true)
+      end
+    end
+
+    describe "#html" do
+      it "does a request" do
+        result = client.html("<html />", StringIO.new)
+
+        expect(result).not_to eq(false)
+        expect(a_request(:post, "http://gotenberg.example.com/forms/chromium/convert/html")).to have_been_made
+      end
+
+      it "forwards options to the API" do
+        result = client.html("<html />", StringIO.new, preferCssPageSize: true)
+
+        expect(WebMock).to have_requested(:post, "http://gotenberg.example.com/forms/chromium/convert/html")
+        .with { |request|
+          parsed_request = parse_multipart_message(request)
+          interesting_part = parsed_request[:parts].find { _1[:part].name == "preferCssPageSize" }
+          expect(interesting_part[:body]).to eq(["true"])
+        }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require "gotenberg"
+require "webmock/rspec"
+
+Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -8,6 +11,8 @@ RSpec.configure do |config|
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+
+  config.include Faraday::Multipart::HelperMethods
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'multipart_parser/reader'
+
+# See https://github.com/lostisland/faraday-multipart/blob/main/spec/support/helper_methods.rb
+module Faraday
+  module Multipart
+    module HelperMethods
+      def multipart_file
+        Faraday::Multipart::FilePart.new(__FILE__, 'text/x-ruby')
+      end
+
+      # parse boundary out of a Content-Type header like:
+      #   Content-Type: multipart/form-data; boundary=gc0p4Jq0M2Yt08jU534c0p
+      def parse_multipart_boundary(ctype)
+        MultipartParser::Reader.extract_boundary_value(ctype)
+      end
+
+      # parse a multipart MIME message, returning a hash of any multipart errors
+      def parse_multipart(boundary, body)
+        reader = MultipartParser::Reader.new(boundary)
+        result = { errors: [], parts: [] }
+
+        def result.part(name)
+          hash = self[:parts].detect { |h| h[:part].name == name }
+          [hash[:part], hash[:body].join]
+        end
+
+        reader.on_part do |part|
+          result[:parts] << thispart = {
+            part: part,
+            body: []
+          }
+          part.on_data do |chunk|
+            thispart[:body] << chunk
+          end
+        end
+        reader.on_error do |msg|
+          result[:errors] << msg
+        end
+        reader.write(body)
+        result
+      end
+
+      def parse_multipart_message(msg)
+        boundary = parse_multipart_boundary(msg.headers['Content-Type'])
+        parse_multipart(boundary, msg.body)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Enables more control over the resulting PDF. Some of the options in https://gotenberg.dev/docs/modules/chromium#routes are nice to have

Potential future work:
- Gotenberg uses camelCase, Ruby prefers snake. Translate.
- Convenience function for page-size that sets pageWidth and pageHeight
- Reject unknown options instead of sending them along